### PR TITLE
Prepare to update bundle build by storing CMA version of CSV in this repo (part 3)

### DIFF
--- a/keda/2.7.1/manifests/cma.v2.7.1.clusterserviceversion.yaml
+++ b/keda/2.7.1/manifests/cma.v2.7.1.clusterserviceversion.yaml
@@ -519,17 +519,23 @@ spec:
             spec:
               containers:
               - args:
+                - -c
+                - export KEDA_OPERATOR_IMAGE=$RELATED_IMAGE_1; export KEDA_METRICS_SERVER_IMAGE=$RELATED_IMAGE_2; exec /manager "$0" "$@"
                 - --leader-elect
                 - --zap-log-level=info
                 - --zap-encoder=console
                 - --zap-time-encoding=rfc3339
                 command:
-                - /manager
+                - /usr/bin/bash
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: RELATED_IMAGE_1
+                  value: CMA_OPERAND_PLACEHOLDER_1
+                - name: RELATED_IMAGE_2
+                  value: CMA_OPERAND_PLACEHOLDER_2
                 image: ghcr.io/kedacore/keda-olm-operator:2.7.1
                 imagePullPolicy: Always
                 livenessProbe:

--- a/keda/2.8.1/manifests/cma.v2.8.1.clusterserviceversion.yaml
+++ b/keda/2.8.1/manifests/cma.v2.8.1.clusterserviceversion.yaml
@@ -519,17 +519,23 @@ spec:
             spec:
               containers:
               - args:
+                - -c
+                - export KEDA_OPERATOR_IMAGE=$RELATED_IMAGE_1; export KEDA_METRICS_SERVER_IMAGE=$RELATED_IMAGE_2; exec /manager "$0" "$@"
                 - --leader-elect
                 - --zap-log-level=info
                 - --zap-encoder=console
                 - --zap-time-encoding=rfc3339
                 command:
-                - /manager
+                - /usr/bin/bash
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: RELATED_IMAGE_1
+                  value: CMA_OPERAND_PLACEHOLDER_1
+                - name: RELATED_IMAGE_2
+                  value: CMA_OPERAND_PLACEHOLDER_2
                 image: ghcr.io/kedacore/keda-olm-operator:2.8.1
                 imagePullPolicy: Always
                 livenessProbe:

--- a/keda/2.8.2/manifests/cma.v2.8.2.clusterserviceversion.yaml
+++ b/keda/2.8.2/manifests/cma.v2.8.2.clusterserviceversion.yaml
@@ -519,17 +519,23 @@ spec:
             spec:
               containers:
               - args:
+                - -c
+                - export KEDA_OPERATOR_IMAGE=$RELATED_IMAGE_1; export KEDA_METRICS_SERVER_IMAGE=$RELATED_IMAGE_2; exec /manager "$0" "$@"
                 - --leader-elect
                 - --zap-log-level=info
                 - --zap-encoder=console
                 - --zap-time-encoding=rfc3339
                 command:
-                - /manager
+                - /usr/bin/bash
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: RELATED_IMAGE_1
+                  value: CMA_OPERAND_PLACEHOLDER_1
+                - name: RELATED_IMAGE_2
+                  value: CMA_OPERAND_PLACEHOLDER_1
                 image: ghcr.io/kedacore/keda-olm-operator:2.8.2
                 imagePullPolicy: Always
                 livenessProbe:


### PR DESCRIPTION
Replacing the images during the build with sed was too fragile and unwieldy. By setting the eventual commands we want to run and providing placeholders for the image pull specs, updating them during the build will be much simpler.