### PR TITLE
OCPNODE-1499: Adds an option to look for CRs in all namespaces

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -61,7 +61,7 @@ cluster_resources+=(ns/$CMA_NS)
 log "Collecting resources for custom-metrics-autoscaler" >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 for resource in ${cluster_resources[@]}; do
   log "Inspecting $resource" >> "${BASE_COLLECTION_PATH}/gather-debug.log"
-  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir ${BASE_COLLECTION_PATH} ${resource} >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+  oc adm inspect --cache-dir=${KUBECACHEDIR} --dest-dir ${BASE_COLLECTION_PATH} --all-namespaces ${resource} >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
   log "Finish inspecting $resource" >> "${BASE_COLLECTION_PATH}/gather-debug.log"
 done
 


### PR DESCRIPTION
This change adds an option to look for CRs in all namespaces while collecting the must-gather information.

Follow-up to 4742d32002f48ff54aa44929e5d30d7842f1c2a5

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

### Checklist

- [x ] Commits are signed with Developer Certificate of Origin (DCO)
