### PR TITLE
Move olm.skipRange from metadata to annotations

### DIFF
--- a/hack/cma-generate-csv.sh
+++ b/hack/cma-generate-csv.sh
@@ -26,13 +26,13 @@ cd "$script_dir"/..
 read -r -d '' cma_patch <<CMA_PATCH_EOF
 metadata:
   annotations:
-   description: Custom Metrics Autoscaler Operator, an event-driven autoscaler based upon KEDA
-   operatorframework.io/suggested-namespace: openshift-keda
-   operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
-   repository: https://github.com/openshift/custom-metrics-autoscaler-operator
-   support: Red Hat
+    description: Custom Metrics Autoscaler Operator, an event-driven autoscaler based upon KEDA
+    operatorframework.io/suggested-namespace: openshift-keda
+    operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+    repository: https://github.com/openshift/custom-metrics-autoscaler-operator
+    support: Red Hat
+    olm.skipRange: ">=2.7.1 <${ver}"
   name: custom-metrics-autoscaler.v${ver}
-  olm.skipRange: ">=2.7.1 <${ver}"
 spec:
   description: "## About the managed application\\nCustom Metrics Autoscaler for OpenShift is an event driven autoscaler based upon KEDA.  Custom Metrics Autoscaler can monitor event sources like Kafka, RabbitMQ, or cloud event sources and feed the metrics from those sources into the Kubernetes horizontal pod autoscaler.  With Custom Metrics Autoscaler, you can have event driven and serverless scale of deployments within any Kubernetes cluster.\\n## About this Operator\\nThe Custom Metrics Autoscaler Operator deploys and manages installation of KEDA Controller in the cluster. Install this operator and follow installation instructions on how to install Custom Metrics Autoscaler in you cluster.\\n\\n## Prerequisites for enabling this Operator\\n## How to install Custom Metrics Autoscaler in the cluster\\nThe installation of Custom Metrics Autoscaler is triggered by the creation of \`KedaController\` resource. Please refer to the [KedaController Spec](https://github.com/openshift/custom-metrics-autoscaler-operator/blob/main/README.md#the-kedacontroller-custom-resource) for more deatils on available options.\\n\\nOnly resource named \`keda\` in namespace \`openshift-keda\` will trigger the installation, reconfiguration or removal of the KEDA Controller resource.\\n\\nThere should be only one KEDA Controller in the cluster. \\n"
   displayName: Custom Metrics Autoscaler

--- a/keda/2.8.2/manifests/cma.v2.8.2.clusterserviceversion.yaml
+++ b/keda/2.8.2/manifests/cma.v2.8.2.clusterserviceversion.yaml
@@ -114,6 +114,7 @@ metadata:
     containerImage: ghcr.io/kedacore/keda-olm-operator:2.8.2
     createdAt: "2023-01-25T00:00:00.000Z"
     description: Custom Metrics Autoscaler Operator, an event-driven autoscaler based upon KEDA
+    olm.skipRange: '>=2.7.1 <2.8.2'
     operatorframework.io/suggested-namespace: openshift-keda
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.23.0
@@ -122,7 +123,6 @@ metadata:
     support: Red Hat
   name: custom-metrics-autoscaler.v2.8.2
   namespace: placeholder
-  olm.skipRange: '>=2.7.1 <2.8.2'
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:


### PR DESCRIPTION
olm.skipRange is supposed to be in the metadata.annotations section of the CSV, not the metadata section. See the example in this section:
https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/operators/understanding-the-operator-lifecycle-manager-olm#olm-upgrades-replacing-multiple_olm-understanding-olm