### PR TITLE
Add annotation for cluster monitoring

### DIFF
--- a/hack/cma-generate-csv.sh
+++ b/hack/cma-generate-csv.sh
@@ -28,7 +28,7 @@ metadata:
   annotations:
     description: Custom Metrics Autoscaler Operator, an event-driven autoscaler based upon KEDA
     operatorframework.io/suggested-namespace: openshift-keda
-    operatorframework.io/cluster-monitoring: true
+    operatorframework.io/cluster-monitoring: "true"
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
     repository: https://github.com/openshift/custom-metrics-autoscaler-operator
     support: Red Hat

--- a/keda/2.8.2/manifests/cma.v2.8.2.clusterserviceversion.yaml
+++ b/keda/2.8.2/manifests/cma.v2.8.2.clusterserviceversion.yaml
@@ -115,7 +115,7 @@ metadata:
     createdAt: "2023-01-25T00:00:00.000Z"
     description: Custom Metrics Autoscaler Operator, an event-driven autoscaler based upon KEDA
     olm.skipRange: '>=2.7.1 <2.8.2'
-    operatorframework.io/cluster-monitoring: true
+    operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-keda
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-v1.23.0


### PR DESCRIPTION
Fix annotation type (boolean to string)

The console expects the string "true" not the boolean value. See:
https://github.com/openshift/console/blob/ab43e3e86f22e19832976f6210748199d29b97c8/frontend/packages/operator-lifecycle-manager/src/components/operator-hub/operator-hub-subscribe.tsx#L147