### PR TITLE
Also set POD_NAMESPACE env var on manager deployment

### DIFF
--- a/resources/keda.yaml
+++ b/resources/keda.yaml
@@ -9589,6 +9589,10 @@ spec:
         command:
         - /keda
         env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: WATCH_NAMESPACE
           value: ""
         - name: KEDA_HTTP_DEFAULT_TIMEOUT


### PR DESCRIPTION
This is a work-around for a bug that is being fixed upstream:
https://github.com/kedacore/keda/pull/4534

Unlike the [webhooks](https://github.com/openshift/custom-metrics-autoscaler-operator/blob/main/resources/keda.yaml#L9402-L9405) and [metrics API server](https://github.com/openshift/custom-metrics-autoscaler-operator/blob/main/resources/keda.yaml#L9496-L9499) deployment, the `POD_NAMESPACE` environment variable is not set by the manager deployment (i.e. `keda-operator`), which causes problems when the manager is deployed to the `openshift-keda` namespace and then tries to create a secret containing its self-signed certs for the gRPC service in the `keda` namespace because the env var wasn't properly set (and it falls back to the default `keda` ns).