### PR TITLE
OCPNODE-1594: Add servicemonitor for webhooks pod, rename servicemonitor for keda

### DIFF
--- a/resources/keda-olm-operator.yaml
+++ b/resources/keda-olm-operator.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: keda-operator-metrics
+  name: keda-operator
   namespace: keda
   labels:
     app.kubernetes.io/name: keda-operator
@@ -32,6 +32,23 @@ spec:
       interval: 60s
   namespaceSelector:
     any: false
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: keda-admission-webhooks
+  name: keda-admission-webhooks
+  namespace: openshift-keda
+spec:
+  endpoints:
+  - interval: 60s
+    port: metrics
+  namespaceSelector:
+    any: false
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: admission-webhooks
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor


### PR DESCRIPTION
Cherry-pick of https://github.com/kedacore/keda-olm-operator/pull/187

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)