### PR TITLE
OCPBUGS-14066: Add OpenShift CA bundle when deployed on OpenShift

### DIFF
--- a/resources/keda-olm-operator.yaml
+++ b/resources/keda-olm-operator.yaml
@@ -39,7 +39,7 @@ metadata:
   labels:
     app.kubernetes.io/name: keda-admission-webhooks
   name: keda-admission-webhooks
-  namespace: openshift-keda
+  namespace: keda
 spec:
   endpoints:
   - interval: 60s


### PR DESCRIPTION
See https://github.com/kedacore/keda-olm-operator/pull/190

Tell the KEDA operator to trust certs signed by the OpenShift service CA so it can get metrics from in-cluster metrics sources like prometheus or an in-cluster kafka.

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)