### PR TITLE
Revert most of PR #39

### DIFF
--- a/hack/cma-generate-csv.sh
+++ b/hack/cma-generate-csv.sh
@@ -61,8 +61,12 @@ jq_filter="$jq_filter"'walk(if type == "string" and . == "keda-olm-operator" the
 jq_filter="$jq_filter"'del(.spec.replaces) | '
 # update the json example CR so that it shows you how to install to "openshift-keda" namespace instead of "keda" namespace
 jq_filter="$jq_filter"'.metadata.annotations."alm-examples" |= sub("\"namespace\": \"keda\""; "\"namespace\": \"openshift-keda\"") | '
-# create a spot to pass in the operand image specs as env vars
-jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name":"KEDA_OPERATOR_IMAGE","value":"CMA_OPERAND_PLACEHOLDER_1"},{"name":"KEDA_METRICS_SERVER_IMAGE","value":"CMA_OPERAND_PLACEHOLDER_2"},{"name":"KEDA_ADMISSION_WEBHOOKS_IMAGE","value":"CMA_OPERAND_PLACEHOLDER_3"}]'
+# set the command to bash instead of /manager
+jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].command |= [ "/usr/bin/bash" ] |'
+# export the env vars and then exec /manager. This hack is needed due to OSBS requiring that env vars have the prefix RELATED_IMAGE_, so bash translates from OSBS-style env vars to operator env vars. See https://osbs.readthedocs.io/en/latest/users.html?highlight=operator#pullspec-locations
+jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].args |= ["-c", "export KEDA_OPERATOR_IMAGE=$RELATED_IMAGE_1; export KEDA_METRICS_SERVER_IMAGE=$RELATED_IMAGE_2; export KEDA_ADMISSION_WEBHOOKS_IMAGE=$RELATED_IMAGE_3; exec /manager \"$0\" \"$@\"" ] + .  |'
+# create a spot to pass in the operand image specs as env vars using OSBS-style RELATED_IMAGE_ names
+jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name":"RELATED_IMAGE_1","value":"CMA_OPERAND_PLACEHOLDER_1"},{"name":"RELATED_IMAGE_2","value":"CMA_OPERAND_PLACEHOLDER_2"},{"name":"RELATED_IMAGE_3","value":"CMA_OPERAND_PLACEHOLDER_3"}]'
 
 # pipe the filtered upstream CSV and the patch together to jq to combine them
 { bin/yaml2json keda/${ver}/manifests/keda.v${ver}.clusterserviceversion.yaml | jq "$jq_filter";

--- a/keda/2.10.1/manifests/cma.v2.10.1.clusterserviceversion.yaml
+++ b/keda/2.10.1/manifests/cma.v2.10.1.clusterserviceversion.yaml
@@ -561,22 +561,24 @@ spec:
             spec:
               containers:
               - args:
+                - -c
+                - export KEDA_OPERATOR_IMAGE=$RELATED_IMAGE_1; export KEDA_METRICS_SERVER_IMAGE=$RELATED_IMAGE_2; export KEDA_ADMISSION_WEBHOOKS_IMAGE=$RELATED_IMAGE_3; exec /manager "$0" "$@"
                 - --leader-elect
                 - --zap-log-level=info
                 - --zap-encoder=console
                 - --zap-time-encoding=rfc3339
                 command:
-                - /manager
+                - /usr/bin/bash
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                - name: KEDA_OPERATOR_IMAGE
+                - name: RELATED_IMAGE_1
                   value: CMA_OPERAND_PLACEHOLDER_1
-                - name: KEDA_METRICS_SERVER_IMAGE
+                - name: RELATED_IMAGE_2
                   value: CMA_OPERAND_PLACEHOLDER_2
-                - name: KEDA_ADMISSION_WEBHOOKS_IMAGE
+                - name: RELATED_IMAGE_3
                   value: CMA_OPERAND_PLACEHOLDER_3
                 image: ghcr.io/kedacore/keda-olm-operator:2.10.1
                 imagePullPolicy: Always


### PR DESCRIPTION
PR #39 (Remove unnecessary bash entrypoint for OLM Operator) actually was removing a hack which turned out to be necessary since the OSBS build requires that related images use env vars beginning with `RELATED_IMAGE_`. See https://osbs.readthedocs.io/en/latest/users.html?highlight=operator#pullspec-locations for details. #39 totally broke the build since OSBS stopped replacing image pull specs with the built images.

The only part of #39 which this doesn't revert is the typo fix which was a separate change and was included in #39 out of laziness (didn't want to make a separate PR for it)

In addition to reverting, a comment has been added at the suggestion of @haircommander to explain the point of the hack.