### PR TITLE
OCPBUGS-14412: Remove SeccompProfile RuntimeDefault from securityContext on old OpenShift clusters

### DIFF
--- a/controllers/keda/suite_test.go
+++ b/controllers/keda/suite_test.go
@@ -97,7 +97,7 @@ var _ = BeforeSuite(func() {
 			Log:    ctrl.Log.WithName("test").WithName("KedaController"),
 			Scheme: k8sManager.GetScheme(),
 		}
-		err = (kedaControllerReconciler).SetupWithManager(k8sManager)
+		err = (kedaControllerReconciler).SetupWithManager(k8sManager, kedaControllerReconciler.Log)
 		Expect(err).ToNot(HaveOccurred())
 
 	} else {

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 	if err = (&kedacontrollers.KedaControllerReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, setupLog); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KedaController")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Cherry pick of https://github.com/kedacore/keda-olm-operator/pull/193