### PR TITLE
OCPBUGS-15590: Use KEDA-specific annotation name for last config, part 2                                                                                

### DIFF
--- a/controllers/keda/kedacontroller_controller.go
+++ b/controllers/keda/kedacontroller_controller.go
@@ -262,31 +262,31 @@ func parseManifestsFromFile(manifest mf.Manifest, c client.Client) (manifestGene
 	}
 
 	manifestClient := mfc.NewClient(c)
-	manifestGeneral, err = mf.ManifestFrom(mf.Slice(generalResources))
+	manifestGeneral, err = mf.ManifestFrom(mf.Slice(generalResources), mf.UseLastAppliedConfigAnnotation(resources.LastConfigID))
 	if err != nil {
 		return mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, err
 	}
 	manifestGeneral.Client = manifestClient
 
-	manifestController, err = mf.ManifestFrom(mf.Slice(controllerResources))
+	manifestController, err = mf.ManifestFrom(mf.Slice(controllerResources), mf.UseLastAppliedConfigAnnotation(resources.LastConfigID))
 	if err != nil {
 		return mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, err
 	}
 	manifestController.Client = manifestClient
 
-	manifestMetrics, err = mf.ManifestFrom(mf.Slice(sortMetricsResources(&metricsResources)))
+	manifestMetrics, err = mf.ManifestFrom(mf.Slice(sortMetricsResources(&metricsResources)), mf.UseLastAppliedConfigAnnotation(resources.LastConfigID))
 	if err != nil {
 		return mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, err
 	}
 	manifestMetrics.Client = manifestClient
 
-	manifestWebhook, err = mf.ManifestFrom(mf.Slice(webhookResources))
+	manifestWebhook, err = mf.ManifestFrom(mf.Slice(webhookResources), mf.UseLastAppliedConfigAnnotation(resources.LastConfigID))
 	if err != nil {
 		return mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, err
 	}
 	manifestWebhook.Client = manifestClient
 
-	manifestMonitoring, err = mf.ManifestFrom(mf.Slice(monitoringResources))
+	manifestMonitoring, err = mf.ManifestFrom(mf.Slice(monitoringResources), mf.UseLastAppliedConfigAnnotation(resources.LastConfigID))
 	if err != nil {
 		return mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, mf.Manifest{}, err
 	}


### PR DESCRIPTION
From upstream https://github.com/kedacore/keda-olm-operator/pull/202                                                                                    

### Checklist

- [X] Commits are signed with Developer Certificate of Origin (DCO)
