### PR TITLE
PODAUTO-63: add Dockerfiles for OpenShift CI builds

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,92 @@
+#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.20)
+#FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.20.5-202307171904.el8.g844e652 AS builder
+# 1. HACK: package channels don't refresh on the cee image if we're running in CI, so use the CI builder instead of the cee one
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 as builder
+
+# 2. HACK: openshift CI doesn't support ENV in image builds, but it does support ARG, so make these ARGs 
+ARG CI_UPSTREAM_VERSION_SANITIZED=main
+ARG CI_CUSTOM_METRICS_AUTOSCALER_OPERATOR_UPSTREAM_COMMIT=HEAD
+ARG CI_CUSTOM_METRICS_AUTOSCALER_OPERATOR_UPSTREAM_VERSION=main
+
+ARG BUILD_VERSION=${CI_UPSTREAM_VERSION_SANITIZED}
+ARG GIT_COMMIT=${CI_CUSTOM_METRICS_AUTOSCALER_OPERATOR_UPSTREAM_COMMIT}
+ARG GIT_VERSION=${CI_CUSTOM_METRICS_AUTOSCALER_OPERATOR_UPSTREAM_VERSION}
+
+
+# 3. HACK: make sure the sources line up with where osbs puts them
+ARG REMOTE_SOURCES_DIR=/src
+ARG REMOTE_SOURCES=.
+COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR/cma-operator/app
+
+WORKDIR $REMOTE_SOURCES_DIR/cma-operator/app
+
+# 4. HACK: osbs feeds in these other sources, there isn't a CI equivalent, so do it here as part of the multistage build
+RUN git clone https://github.com/kubernetes-sigs/controller-tools $REMOTE_SOURCES_DIR/controller-tools/app && touch $REMOTE_SOURCES_DIR/controller-tools/cachito.env
+RUN git clone https://github.com/golang/mock $REMOTE_SOURCES_DIR/mockgen/app && touch $REMOTE_SOURCES_DIR/mockgen/cachito.env
+RUN git clone https://github.com/protocolbuffers/protobuf $REMOTE_SOURCES_DIR/protobuf/app && touch $REMOTE_SOURCES_DIR/protobuf/cachito.env && rm -rf ./$REMOTE_SOURCES_DIR/protobuf/app/examples
+RUN touch ../cachito.env
+
+RUN dnf install -y protobuf-compiler
+RUN mkdir -p $REMOTE_SOURCES_DIR/cma-operator/app/bin
+RUN cd $REMOTE_SOURCES_DIR/controller-tools/app && source ../cachito.env && \
+    GOFLAGS="" go build -o $REMOTE_SOURCES_DIR/cma-operator/app/bin/controller-gen ./cmd/controller-gen
+RUN cd $REMOTE_SOURCES_DIR/mockgen/app && source ../cachito.env && \
+    GOFLAGS="" go build -o $REMOTE_SOURCES_DIR/cma-operator/app/bin/mockgen ./mockgen
+RUN cd $REMOTE_SOURCES_DIR/protobuf/app && source ../cachito.env && cd src/google && \
+    for f in $(find protobuf/ -name '*.proto'); do mkdir -p /usr/include/google/"$(dirname "$f")"; cp "$f" /usr/include/google/"$f"; done
+
+# update the OLM operator name
+RUN sed -i '/^kind: PodMonitor$/,$ s/\(name: *\)keda-olm-operator$/\1custom-metrics-autoscaler-operator/' \
+        resources/keda-olm-operator.yaml
+
+RUN echo VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} && \
+    source ../cachito.env && \
+    GOFLAGS="" VERSION=${BUILD_VERSION} GIT_COMMIT=${GIT_COMMIT} GIT_VERSION=${GIT_VERSION} make build
+
+#@follow_tag(registry.redhat.io/openshift4/ose-cli:latest)
+FROM registry.redhat.io/openshift4/ose-cli:latest AS cli
+
+#@follow_tag(registry.redhat.io/ubi8/ubi-minimal:latest)
+FROM registry.redhat.io/ubi8/ubi-minimal:latest
+
+# 5. HACK: have to mention the arg for it to be usable here
+ARG REMOTE_SOURCES_DIR=/src
+
+# install required tools for must-gather collection script
+RUN INSTALL_PKGS=" \
+      rsync \
+      tar \
+      " && \
+    microdnf install -y $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    microdnf clean all
+
+WORKDIR /
+COPY --from=builder $REMOTE_SOURCES_DIR/cma-operator/app/resources/*.yaml /resources/
+COPY --from=builder $REMOTE_SOURCES_DIR/cma-operator/app/bin/manager /usr/bin/
+RUN ln -s /usr/bin/manager /manager
+
+COPY --from=builder $REMOTE_SOURCES_DIR/cma-operator/app/must-gather/collection-scripts/* /usr/bin/
+COPY --from=cli /usr/bin/oc /usr/bin
+RUN ln -s /usr/bin/oc /usr/bin/kubectl
+
+RUN mkdir -p $REMOTE_SOURCES_DIR/cma-operator/app && \
+    ln -s /resources $REMOTE_SOURCES_DIR/cma-operator/app/resources
+USER nobody
+
+LABEL io.k8s.display-name="OpenShift Custom Metrics Autoscaler Operator" \
+      io.k8s.description="This is a component of OpenShift which manages Custom Metrics Autoscaler." \
+      com.redhat.component="custom-metrics-autoscaler-operator-container" \
+      name="custom-metrics-autoscaler-operator-rhel-8" \
+      version="${CI_UPSTREAM_VERSION_SANITIZED}" \
+      release="${CI_SPEC_RELEASE}" \
+      upstream-version="${CI_CUSTOM_METRICS_AUTOSCALER_OPERATOR_UPSTREAM_VERSION}" \
+      upstream-vcs-ref="${CI_CUSTOM_METRICS_AUTOSCALER_OPERATOR_UPSTREAM_COMMIT}" \
+      upstream-vcs-type="git" \
+      summary="custom-metrics-autoscaler-operator" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,custom-metrics-autoscaler-operator" \
+      description="custom-metrics-autoscaler-operator-container" \
+      maintainer="AOS node team <aos-node@redhat.com>"
+
+CMD ["/usr/bin/manager"]

--- a/bundle.Dockerfile.ci
+++ b/bundle.Dockerfile.ci
@@ -1,0 +1,43 @@
+# This enables us to build a release-ish image in CI. It won't be exactly the same as what we release, 
+# but it should approximate it well enough for now that it gives us some signal. 
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 as builder
+
+# we need to build some things so we need the sources
+COPY . . 
+
+
+# bundle off our most recent release 
+RUN VERSION=$(ls keda/ | sort -V  | tail -1) && \ 
+  mv keda/$VERSION/manifests /manifests && \ 
+  mv keda/$VERSION/metadata  /metadata 
+       
+# if there are two csvs, the bundle will not validate, so delete the upstream one now that we're done using it
+RUN rm /manifests/keda.*.clusterserviceversion.yaml
+
+
+FROM scratch
+
+COPY --from=builder ./manifests/ /manifests/
+COPY --from=builder ./metadata/ /metadata/
+
+# OpenShift bundle labels 
+LABEL com.redhat.component="custom-metrics-autoscaler-operator-bundle-container" \
+      name="custom-metrics-autoscaler-operator-metadata-rhel-8" \
+      version="v0.0.0" \
+      summary="Custom Metrics Autoscaler for OpenShift bundle image" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,custom-metrics-autoscaler-operator" \
+      io.k8s.display-name="openshift-custom-metrics-autoscaler-operator" \
+      maintainer="AOS workloads team, <aos-workloads@redhat.com>" \
+      description="Custom Metrics Autoscaler for OpenShift bundle image" \
+      com.redhat.delivery.operator.bundle=true \
+      com.redhat.openshift.versions="v4.15" \
+      operators.operatorframework.io.bundle.channel.default.v1=stable \
+      operators.operatorframework.io.bundle.channels.v1=stable \
+      operators.operatorframework.io.bundle.manifests.v1=manifests/ \
+      operators.operatorframework.io.bundle.mediatype.v1="registry+v1" \
+      operators.operatorframework.io.bundle.metadata.v1=metadata/ \
+      operators.operatorframework.io.bundle.package.v1="openshift-custom-metrics-autoscaler-operator"
+
+


### PR DESCRIPTION
The thought here is that we want t orun the e2e suite, but we want to run it against something like what we're actually going to release, so instead of using the synthetic setup/teardown functions from the keda tests, we try to pack a proper bundle and install from that.

This contains two dockerfiles. 

`Dockerfile.ci` which:
- Builds the cma operator with the openshift builder/release images (instead of the upstream builder image + distroless)  and tries to be as close to the osbs way as possible given our CI limitations, so we're testing something that's fairly close to what we ship 

`bundle.Dockerfile.ci` which:
- Might be too complicated :smile:
- Attempts to perform the "release steps" against the repo to generate a new v99.0.0 bundle that can be built by OpenShift CI's bundle builder, and will allow for image overrides in CI much like in osbs. 
- ( CI's bundle pullspec rewrites happen BEFORE the bundle is packed, it appends docker commands to the build, so the multi-stage builder here works, but we can't generate any NEW manifests as part of the build because they won't be rewritten) 

To be used with the CI config in https://github.com/openshift/release/pull/44184

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->