### PR TITLE
OCPBUGS-37989: Fix writeable root fs downstream

### DIFF
--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -633,6 +633,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,7 @@ spec:
             capabilities:
               drop:
               - ALL
+            readOnlyRootFilesystem: true
           ports:
             - containerPort: 8080
               name: http

--- a/config/manifests/bases/keda.clusterserviceversion.yaml
+++ b/config/manifests/bases/keda.clusterserviceversion.yaml
@@ -630,6 +630,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates

--- a/keda/2.14.1/manifests/cma.v2.14.1.clusterserviceversion.yaml
+++ b/keda/2.14.1/manifests/cma.v2.14.1.clusterserviceversion.yaml
@@ -648,6 +648,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates

--- a/keda/2.14.1/manifests/keda.v2.14.1.clusterserviceversion.yaml
+++ b/keda/2.14.1/manifests/keda.v2.14.1.clusterserviceversion.yaml
@@ -630,6 +630,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: certificates


### PR DESCRIPTION
Downstream cherry-pick of https://github.com/kedacore/keda-olm-operator/pull/243. 

Broke the 2.14.1 CMA CSV change into a separate commit so it didn't get dropped later, I figure we can squash it during the next rebase. 

Fixes [OCPBUGS-37989](https://issues.redhat.com/browse/OCPBUGS-37989)
