### PR TITLE
AUTOSCALE-651: Break e2e commands out into make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,40 @@ publish: docker-build docker-push ## Build & push docker image with the manager.
 sign-images: ## Sign KEDA images published on GitHub Container Registry
 	COSIGN_EXPERIMENTAL=1 cosign sign ${COSIGN_FLAGS} $(IMAGE_CONTROLLER)
 
+##@ E2E Testing
+
+# e2e-cma-setup is called by CI after the CMA operator is installed via OLM
+# (operator-sdk run bundle). It creates the KedaController CR that instructs
+# the operator to deploy the KEDA operand (keda-operator, keda-metrics-apiserver,
+# keda-admission-webhooks).
+#
+# WHY THIS EXISTS / WHY IT LOOKS THE WAY IT DOES:
+#
+# Upstream KEDA (kedacore/keda) deploys the operand directly with kustomize and 
+# does things like patch the keda deployment directly for file-based auth. 
+#
+# We cannot use that kustomize path because CMA deploys the operand through the
+# OLM operator: the operator embeds the base operand manifests and applies
+# configuration at runtime via its transform layer, driven by the KedaController
+# CR spec. There are no kustomize overlays at deploy time.
+#
+# So to exercise things the same file-based auth code path, we need to find equivalent
+# ways to test the functionality via the KedaController.
+#
+# If the operand/upstream changes their file_auth overlay (config/e2e/file_auth/patch_operator.yml
+# in the keda repo), or otherwise changes their e2e setup in a way that has olm operator 
+# ramifications, we may need to adjust this to stay in sync.
+.PHONY: e2e-cma-setup
+e2e-cma-setup: ## Set up KEDA for CMA e2e tests (called by CI after OLM install)
+	oc apply -n keda -f config/e2e/file-auth-secret.yaml
+	oc apply -n keda -f config/e2e/keda_v1alpha1_kedacontroller.yaml
+	sleep 30
+	oc get deployment -n keda
+	oc wait --for condition=Available -n keda deployment keda-admission --timeout 10m
+	oc wait --for condition=Available -n keda deployment keda-metrics-apiserver --timeout 10m
+	oc wait --for condition=Available -n keda deployment keda-operator --timeout 10m
+	oc get deployment -n keda
+
 ##@ Deployment
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.

--- a/config/e2e/file-auth-secret.yaml
+++ b/config/e2e/file-auth-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: file-auth-creds
+  namespace: keda
+stringData:
+  creds.json: '{"authMode":"bearer","token":"e2e-mock-test-bearer-token"}'

--- a/config/e2e/keda_v1alpha1_kedacontroller.yaml
+++ b/config/e2e/keda_v1alpha1_kedacontroller.yaml
@@ -1,0 +1,32 @@
+apiVersion: keda.sh/v1alpha1
+kind: KedaController
+metadata:
+  name: keda
+  namespace: keda
+spec:
+  watchNamespace: ""
+
+  operator:
+    logLevel: info
+    logEncoder: console
+    networkEgressAllowAll: "true"
+    args:
+      - "--filepath-auth-root-path=/mnt/auth"
+    volumes:
+      - name: auth-volume
+        secret:
+          secretName: file-auth-creds
+    volumeMounts:
+      - name: auth-volume
+        mountPath: /mnt/auth
+        readOnly: true
+
+  metricsServer:
+    logLevel: "0"
+    networkEgressAllowAll: "true"
+
+  admissionWebhooks:
+    logLevel: info
+    logEncoder: console
+
+  serviceAccount: {}


### PR DESCRIPTION
This: 
- Peels the e2e commands for operator setup out of CI and into the repo 
- Adds a specific e2e fixture KedaController (vs using the sample) because we probably don't want our canonical sample to have file-based auth slop in it that nobody is using 
- Adds a secret for file-based auth that will get set up as part of the e2e setup 
- Adds a makefile target to invoke the e2e setup 
- This will be a no-op until my follow-up PR in CI 

Because the operand is using kustomize to patch the deployment on setup, and we can't. 

We could also mark the test out, but I assume we don't want to do that :smile: 
