### PR TITLE
OCPBUGS-56383: create Prometheus monitoring RBAC on CLI install

### DIFF
--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -395,6 +395,13 @@ func (r *KedaControllerReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		return ctrl.Result{}, err
 	}
+	if err := r.ensurePrometheusMonitoringRBAC(ctx, logger, instance); err != nil {
+		status.MarkInstallFailed("Not able to ensure Prometheus monitoring RBAC")
+		if statusErr := util.UpdateKedaControllerStatus(ctx, r.Client, instance, status); statusErr != nil {
+			err = fmt.Errorf("got error: %s and then another: %s", err, statusErr)
+		}
+		return ctrl.Result{}, err
+	}
 	if err := r.installController(ctx, logger, instance); err != nil {
 		status.MarkInstallFailed("Not able to install KEDA Controller")
 		if statusErr := util.UpdateKedaControllerStatus(ctx, r.Client, instance, status); statusErr != nil {

--- a/internal/controller/keda/prometheus_rbac.go
+++ b/internal/controller/keda/prometheus_rbac.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2020 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keda
+
+import (
+	"context"
+	"reflect"
+
+	goerrors "errors"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
+	"github.com/kedacore/keda-olm-operator/internal/controller/keda/util"
+)
+
+const (
+	clusterMonitoringLabel       = "openshift.io/cluster-monitoring"
+	prometheusMonitoringSAName   = "prometheus-k8s"
+	prometheusMonitoringSANamespace = "openshift-monitoring"
+)
+
+// prometheusRBACName returns the Role and RoleBinding name used by the OpenShift console
+// when cluster monitoring is enabled for an operator namespace.
+func prometheusRBACName(namespace string) string {
+	return namespace + "-prometheus"
+}
+
+func prometheusRoleRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"services", "endpoints", "pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+}
+
+func namespaceHasClusterMonitoringEnabled(ns *corev1.Namespace) bool {
+	if ns == nil || ns.Labels == nil {
+		return false
+	}
+	return ns.Labels[clusterMonitoringLabel] == "true"
+}
+
+// ensurePrometheusMonitoringRBAC creates Role and RoleBinding that allow OpenShift cluster
+// monitoring (prometheus-k8s) to discover targets in the operator namespace. The web console
+// creates the same objects on OperatorHub install; this ensures CLI installs behave the same.
+func (r *KedaControllerReconciler) ensurePrometheusMonitoringRBAC(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController) error {
+	if !util.RunningOnOpenshift(ctx, logger, r.Client) {
+		return nil
+	}
+
+	ns := &corev1.Namespace{}
+	if err := r.Get(ctx, types.NamespacedName{Name: instance.Namespace}, ns); err != nil {
+		if errors.IsNotFound(err) {
+			logger.V(4).Info("Operator namespace not found, skipping Prometheus monitoring RBAC")
+			return nil
+		}
+		return err
+	}
+
+	if !namespaceHasClusterMonitoringEnabled(ns) {
+		logger.V(4).Info("Cluster monitoring not enabled for namespace, skipping Prometheus monitoring RBAC", "namespace", instance.Namespace)
+		return nil
+	}
+
+	rbacName := prometheusRBACName(instance.Namespace)
+	logger.Info("Ensuring Prometheus monitoring RBAC exists", "namespace", instance.Namespace, "name", rbacName)
+
+	if err := r.ensurePrometheusRole(ctx, logger, instance, rbacName); err != nil {
+		return err
+	}
+	if err := r.ensurePrometheusRoleBinding(ctx, logger, instance, rbacName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *KedaControllerReconciler) ensurePrometheusRole(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController, rbacName string) error {
+	desired := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rbacName,
+			Namespace: instance.Namespace,
+		},
+		Rules: prometheusRoleRules(),
+	}
+
+	existing := &rbacv1.Role{}
+	err := r.Get(ctx, types.NamespacedName{Name: rbacName, Namespace: instance.Namespace}, existing)
+	if errors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
+			logger.Error(err, "Failed to set controller reference for Prometheus Role")
+			return err
+		}
+		if err := r.Create(ctx, desired); err != nil {
+			logger.Error(err, "Failed to create Prometheus monitoring Role")
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(existing.Rules, desired.Rules) {
+		existing.Rules = desired.Rules
+		if err := r.Update(ctx, existing); err != nil {
+			logger.Error(err, "Failed to update Prometheus monitoring Role")
+			return err
+		}
+	}
+
+	if err := controllerutil.SetControllerReference(instance, existing, r.Scheme); err != nil {
+		if !goerrors.Is(err, &controllerutil.AlreadyOwnedError{}) {
+			logger.Error(err, "Failed to set controller reference for Prometheus Role")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *KedaControllerReconciler) ensurePrometheusRoleBinding(ctx context.Context, logger logr.Logger, instance *kedav1alpha1.KedaController, rbacName string) error {
+	desired := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rbacName,
+			Namespace: instance.Namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     rbacName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      prometheusMonitoringSAName,
+				Namespace: prometheusMonitoringSANamespace,
+			},
+		},
+	}
+
+	existing := &rbacv1.RoleBinding{}
+	err := r.Get(ctx, types.NamespacedName{Name: rbacName, Namespace: instance.Namespace}, existing)
+	if errors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
+			logger.Error(err, "Failed to set controller reference for Prometheus RoleBinding")
+			return err
+		}
+		if err := r.Create(ctx, desired); err != nil {
+			logger.Error(err, "Failed to create Prometheus monitoring RoleBinding")
+			return err
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	needsUpdate := !reflect.DeepEqual(existing.RoleRef, desired.RoleRef) || !reflect.DeepEqual(existing.Subjects, desired.Subjects)
+	if needsUpdate {
+		existing.RoleRef = desired.RoleRef
+		existing.Subjects = desired.Subjects
+		if err := r.Update(ctx, existing); err != nil {
+			logger.Error(err, "Failed to update Prometheus monitoring RoleBinding")
+			return err
+		}
+	}
+
+	if err := controllerutil.SetControllerReference(instance, existing, r.Scheme); err != nil {
+		if !goerrors.Is(err, &controllerutil.AlreadyOwnedError{}) {
+			logger.Error(err, "Failed to set controller reference for Prometheus RoleBinding")
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/keda/prometheus_rbac_test.go
+++ b/internal/controller/keda/prometheus_rbac_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2020 The KEDA Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keda
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPrometheusRBACName(t *testing.T) {
+	if got := prometheusRBACName("openshift-keda"); got != "openshift-keda-prometheus" {
+		t.Fatalf("prometheusRBACName() = %q, want openshift-keda-prometheus", got)
+	}
+}
+
+func TestPrometheusRoleRules(t *testing.T) {
+	rules := prometheusRoleRules()
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+
+	rule := rules[0]
+	if len(rule.APIGroups) != 1 || rule.APIGroups[0] != "" {
+		t.Fatalf("unexpected APIGroups: %#v", rule.APIGroups)
+	}
+	if len(rule.Resources) != 3 {
+		t.Fatalf("unexpected resources: %#v", rule.Resources)
+	}
+	wantResources := map[string]bool{"services": true, "endpoints": true, "pods": true}
+	for _, res := range rule.Resources {
+		if !wantResources[res] {
+			t.Fatalf("unexpected resource %q", res)
+		}
+	}
+	if len(rule.Verbs) != 3 {
+		t.Fatalf("unexpected verbs: %#v", rule.Verbs)
+	}
+	wantVerbs := map[string]bool{"get": true, "list": true, "watch": true}
+	for _, verb := range rule.Verbs {
+		if !wantVerbs[verb] {
+			t.Fatalf("unexpected verb %q", verb)
+		}
+	}
+}
+
+func TestNamespaceHasClusterMonitoringEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		ns   *corev1.Namespace
+		want bool
+	}{
+		{
+			name: "enabled",
+			ns: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{clusterMonitoringLabel: "true"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "disabled value",
+			ns: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{clusterMonitoringLabel: "false"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "missing label",
+			ns: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil namespace",
+			ns:   nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := namespaceHasClusterMonitoringEnabled(tt.ns); got != tt.want {
+				t.Fatalf("namespaceHasClusterMonitoringEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrometheusRoleBindingSubjects(t *testing.T) {
+	rb := &rbacv1.RoleBinding{
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      prometheusMonitoringSAName,
+				Namespace: prometheusMonitoringSANamespace,
+			},
+		},
+	}
+
+	if len(rb.Subjects) != 1 {
+		t.Fatalf("expected 1 subject, got %d", len(rb.Subjects))
+	}
+	subject := rb.Subjects[0]
+	if subject.Name != "prometheus-k8s" || subject.Namespace != "openshift-monitoring" {
+		t.Fatalf("unexpected subject: %#v", subject)
+	}
+}


### PR DESCRIPTION
## Summary

When Custom Metrics Autoscaler (CMA) is installed via CLI/OLM and the operator namespace has `openshift.io/cluster-monitoring=true`, the OpenShift console creates `{namespace}-prometheus` Role and RoleBinding so `prometheus-k8s` can discover scrape targets. CLI install does not create these objects, which leads to forbidden errors in Prometheus for the operator namespace.

This change ensures the same Role and RoleBinding during `KedaController` reconcile on OpenShift when cluster monitoring is enabled for the operator namespace.

Permissions match the console behavior ([openshift/console#5529](https://github.com/openshift/console/pull/5529)):
- **Resources:** `services`, `endpoints`, `pods`
- **Verbs:** `get`, `list`, `watch`
- **Subject:** `prometheus-k8s` in `openshift-monitoring`

## Jira

https://redhat.atlassian.net/browse/OCPBUGS-56383

## Changes

- Add `ensurePrometheusMonitoringRBAC` in `internal/controller/keda/prometheus_rbac.go`
- Call it from `KedaController` reconcile after general resources are installed
- Add unit tests in `prometheus_rbac_test.go`

## Test plan

- [x] `go test ./internal/controller/keda/ -run TestPrometheus`
- [x] Reproduced on OCP 4.22.0-rc.4 / CMA 2.19.0-1: CLI install → `openshift-keda-prometheus` Role/RoleBinding missing; Prometheus forbidden errors for `openshift-keda`
- [x] With fix: operator logs `Ensuring Prometheus monitoring RBAC exists`
- [x] `Role` and `RoleBinding` `openshift-keda-prometheus` created in `openshift-keda`
- [x] No new Prometheus forbidden errors for `openshift-keda` after RBAC creation (`--since-time` on `prometheus-k8s-0` and `prometheus-k8s-1`)
- [ ] Downstream CI / merge verification