### PR TITLE
Fix OLM upgrade failure: remove app.kubernetes.io/version from operator Deployment selector (AUTOSCALE-825)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && \
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-olm-operator=${IMAGE_CONTROLLER}
 	cd config/default && \
-    $(KUSTOMIZE) edit add label -f app.kubernetes.io/version:${VERSION}
+    $(KUSTOMIZE) edit add label --without-selector --include-templates -f app.kubernetes.io/version:${VERSION}
 	$(KUSTOMIZE) build config/default | kubectl apply --server-side -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
@@ -225,7 +225,7 @@ bundle: manifests kustomize	## Generate bundle manifests and metadata, then vali
 	cd config/manager && \
 		$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-olm-operator=${IMAGE_CONTROLLER}
 	cd config/default && \
-  	$(KUSTOMIZE) edit add label -f app.kubernetes.io/version:${VERSION}
+  	$(KUSTOMIZE) edit add label --without-selector --include-templates -f app.kubernetes.io/version:${VERSION}
 	operator-sdk generate kustomize manifests -q
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle

--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -682,7 +682,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: keda-olm-operator
-              app.kubernetes.io/version: main
               name: keda-olm-operator
           strategy: {}
           template:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -44,4 +44,8 @@ resources:
 - ../manager
 commonLabels:
   app.kubernetes.io/part-of: keda-olm-operator
-  app.kubernetes.io/version: main
+labels:
+- pairs:
+    app.kubernetes.io/version: main
+  includeSelectors: false
+  includeTemplates: true

--- a/config/manifests/bases/keda.clusterserviceversion.yaml
+++ b/config/manifests/bases/keda.clusterserviceversion.yaml
@@ -682,7 +682,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: keda-olm-operator
-              app.kubernetes.io/version: main
               name: keda-olm-operator
           strategy: {}
           template:

--- a/hack/cma-generate-csv.sh
+++ b/hack/cma-generate-csv.sh
@@ -93,7 +93,9 @@ jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.cont
 # export the env vars and then exec /manager. This hack is needed due to OSBS requiring that env vars have the prefix RELATED_IMAGE_, so bash translates from OSBS-style env vars to operator env vars. See https://osbs.readthedocs.io/en/latest/users.html?highlight=operator#pullspec-locations
 jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].args |= ["-c", "export KEDA_OPERATOR_IMAGE=$RELATED_IMAGE_1; export KEDA_METRICS_SERVER_IMAGE=$RELATED_IMAGE_2; export KEDA_ADMISSION_WEBHOOKS_IMAGE=$RELATED_IMAGE_3; exec /manager \"$0\" \"$@\"" ] + .  |'
 # create a spot to pass in the operand image specs as env vars using OSBS-style RELATED_IMAGE_ names
-jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name":"RELATED_IMAGE_1","value":"CMA_OPERAND_PLACEHOLDER_1"},{"name":"RELATED_IMAGE_2","value":"CMA_OPERAND_PLACEHOLDER_2"},{"name":"RELATED_IMAGE_3","value":"CMA_OPERAND_PLACEHOLDER_3"}]'
+jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name":"RELATED_IMAGE_1","value":"CMA_OPERAND_PLACEHOLDER_1"},{"name":"RELATED_IMAGE_2","value":"CMA_OPERAND_PLACEHOLDER_2"},{"name":"RELATED_IMAGE_3","value":"CMA_OPERAND_PLACEHOLDER_3"}] | '
+# Deployment selectors are immutable; never include app.kubernetes.io/version in matchLabels
+jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.selector.matchLabels |= del(.["app.kubernetes.io/version"])'
 
 # pipe the filtered upstream CSV and the patch together to jq to combine them
 { bin/yaml2json keda/${ver}/manifests/keda.v${ver}.clusterserviceversion.yaml | jq "$jq_filter";

--- a/keda/2.19.0/manifests/cma.v2.19.0.clusterserviceversion.yaml
+++ b/keda/2.19.0/manifests/cma.v2.19.0.clusterserviceversion.yaml
@@ -691,7 +691,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: custom-metrics-autoscaler-operator
-              app.kubernetes.io/version: main
               name: custom-metrics-autoscaler-operator
           strategy: {}
           template:

--- a/keda/2.19.0/manifests/keda.v2.19.0.clusterserviceversion.yaml
+++ b/keda/2.19.0/manifests/keda.v2.19.0.clusterserviceversion.yaml
@@ -682,7 +682,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: keda-olm-operator
-              app.kubernetes.io/version: main
               name: keda-olm-operator
           strategy: {}
           template:


### PR DESCRIPTION
## Summary

- Remove `app.kubernetes.io/version` from operator Deployment `selector.matchLabels` in v2.19.0 CSVs so OLM upgrades from v2.18.x succeed (selector matchLabels are immutable).
- Keep `app.kubernetes.io/version` on Deployment metadata (`deployments[].label`) and pod template labels.
- Fix kustomize/Makefile so future bundles do not inject version into selectors (`includeSelectors: false`).
- Add jq guard in `cma-generate-csv.sh` for CMA CSV generation.

**Jira:** https://redhat.atlassian.net/browse/AUTOSCALE-825

## Root cause

`v2.19.0-1` added `app.kubernetes.io/version: main` to the Deployment selector. `v2.18.1-2` did not include this label in the selector. Kubernetes rejects selector changes on upgrade, causing CSV `Failed` / `InstallComponentFailed`.

## Release note

`custom-metrics-autoscaler.v2.19.0-1` cannot be fixed in the live catalog. A new bundle (e.g. `v2.19.0-2`) must be built from this fix after merge.

## Test plan

- [ ] Cluster test on OpenShift with v2.18.1-2 → failed v2.19.0-1 CSV
- [ ] CSV install selector patched to match PR fix — CSV reaches `Succeeded`
- [ ] Selector has only `app.kubernetes.io/part-of` + `name` (no version)
- [ ] Pod template retains `app.kubernetes.io/version`
- [ ] Operator pod `Running`