### PR TITLE
OCPBUGS-91950: Fix erroneous deployment selector regression 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && \
 	$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-olm-operator=${IMAGE_CONTROLLER}
 	cd config/default && \
-    $(KUSTOMIZE) edit add label -f app.kubernetes.io/version:${VERSION}
+    $(KUSTOMIZE) edit add label --without-selector --include-templates -f app.kubernetes.io/version:${VERSION}
 	$(KUSTOMIZE) build config/default | kubectl apply --server-side -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
@@ -225,7 +225,7 @@ bundle: manifests kustomize	## Generate bundle manifests and metadata, then vali
 	cd config/manager && \
 		$(KUSTOMIZE) edit set image ghcr.io/kedacore/keda-olm-operator=${IMAGE_CONTROLLER}
 	cd config/default && \
-  	$(KUSTOMIZE) edit add label -f app.kubernetes.io/version:${VERSION}
+  	$(KUSTOMIZE) edit add label --without-selector --include-templates -f app.kubernetes.io/version:${VERSION}
 	operator-sdk generate kustomize manifests -q
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle

--- a/bundle/manifests/keda.clusterserviceversion.yaml
+++ b/bundle/manifests/keda.clusterserviceversion.yaml
@@ -682,7 +682,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: keda-olm-operator
-              app.kubernetes.io/version: main
               name: keda-olm-operator
           strategy: {}
           template:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -44,4 +44,8 @@ resources:
 - ../manager
 commonLabels:
   app.kubernetes.io/part-of: keda-olm-operator
-  app.kubernetes.io/version: main
+labels:
+- pairs:
+    app.kubernetes.io/version: main
+  includeSelectors: false
+  includeTemplates: true

--- a/config/manifests/bases/keda.clusterserviceversion.yaml
+++ b/config/manifests/bases/keda.clusterserviceversion.yaml
@@ -682,7 +682,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: keda-olm-operator
-              app.kubernetes.io/version: main
               name: keda-olm-operator
           strategy: {}
           template:

--- a/hack/cma-generate-csv.sh
+++ b/hack/cma-generate-csv.sh
@@ -93,7 +93,9 @@ jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.cont
 # export the env vars and then exec /manager. This hack is needed due to OSBS requiring that env vars have the prefix RELATED_IMAGE_, so bash translates from OSBS-style env vars to operator env vars. See https://osbs.readthedocs.io/en/latest/users.html?highlight=operator#pullspec-locations
 jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].args |= ["-c", "export KEDA_OPERATOR_IMAGE=$RELATED_IMAGE_1; export KEDA_METRICS_SERVER_IMAGE=$RELATED_IMAGE_2; export KEDA_ADMISSION_WEBHOOKS_IMAGE=$RELATED_IMAGE_3; exec /manager \"$0\" \"$@\"" ] + .  |'
 # create a spot to pass in the operand image specs as env vars using OSBS-style RELATED_IMAGE_ names
-jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name":"RELATED_IMAGE_1","value":"CMA_OPERAND_PLACEHOLDER_1"},{"name":"RELATED_IMAGE_2","value":"CMA_OPERAND_PLACEHOLDER_2"},{"name":"RELATED_IMAGE_3","value":"CMA_OPERAND_PLACEHOLDER_3"}]'
+jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.template.spec.containers[0].env += [{"name":"RELATED_IMAGE_1","value":"CMA_OPERAND_PLACEHOLDER_1"},{"name":"RELATED_IMAGE_2","value":"CMA_OPERAND_PLACEHOLDER_2"},{"name":"RELATED_IMAGE_3","value":"CMA_OPERAND_PLACEHOLDER_3"}] | '
+# Deployment selectors are immutable; never include app.kubernetes.io/version in matchLabels
+jq_filter="$jq_filter"'.spec.install.spec.deployments[0].spec.selector.matchLabels |= del(.["app.kubernetes.io/version"])'
 
 # pipe the filtered upstream CSV and the patch together to jq to combine them
 { bin/yaml2json keda/${ver}/manifests/keda.v${ver}.clusterserviceversion.yaml | jq "$jq_filter";

--- a/keda/2.19.0/manifests/cma.v2.19.0.clusterserviceversion.yaml
+++ b/keda/2.19.0/manifests/cma.v2.19.0.clusterserviceversion.yaml
@@ -691,7 +691,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: custom-metrics-autoscaler-operator
-              app.kubernetes.io/version: main
               name: custom-metrics-autoscaler-operator
           strategy: {}
           template:

--- a/keda/2.19.0/manifests/keda.v2.19.0.clusterserviceversion.yaml
+++ b/keda/2.19.0/manifests/keda.v2.19.0.clusterserviceversion.yaml
@@ -682,7 +682,6 @@ spec:
           selector:
             matchLabels:
               app.kubernetes.io/part-of: keda-olm-operator
-              app.kubernetes.io/version: main
               name: keda-olm-operator
           strategy: {}
           template:


### PR DESCRIPTION
This is https://github.com/openshift/custom-metrics-autoscaler-operator/pull/88 with adjusted commit naming and a deployment rename to force OLM to do a delete-recreate on the deployment so upgrades out of the "bad version" are seamless. 

- We shipped a 2.19.0-1 that let `app.kubernetes.io/version` sneak through as a selector
- Anyone who already had CMA installed would fail to upgrade because the selector is immutable 
- In order to get rid of the bad selector, someone (either or user or us) has do delete the deployment and recreate it 
- ~The only way to do that in OLM is apparently still to rename the deployment~
- ~This renames the deployment to `custom-metrics-autoscaler-operator-v2` as a <drop> commit~
  - ~so the name will flip back next time for 2.20.1 and anyone who never installed 2.19.0-1 will see no differences~

TL;DR: 
- one commit for upstream parity (conditional/numbered carry until we rebase) 
- one commit for the safety (carry, we keep forever so this never happens again) 
- ~one commit for the rename/redeploy for seamless upgrades ( drop, I assume we want to revert to the old naming after this release)~ 