### PR TITLE
test: verify cloudevent_source e2e on main (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,3 +693,5 @@ To build the operator:
 ```bash
 make build
 ```
+
+<!-- TEMPORARY CI TEST — do not merge. Opened to verify the cloudevent_source e2e test on main. -->


### PR DESCRIPTION
## Purpose

**Temporary / do-not-merge.** This PR exists only to run the `cma-e2e-aws-ovn` and `cma-e2e-gcp-ovn` jobs against the pristine `main` branch.

## Context

On the rebase PR #91, `TestScaledObjectGeneral` in `tests/internals/cloudevent_source` fails on both AWS and GCP. The failure is isolated to the test's Kubernetes-Event watch (field selector `reason=ScaledObjectCheckFailed,type=Warning`) timing out, while the CloudEvents themselves are received. This PR checks whether the same test also fails on `main` (independent of the rebase), to determine if it's a pre-existing / environment issue vs. a regression introduced by the rebase.

The only change is a comment appended to `README.md`.