### PR TITLE
AUTOSCALE-841: Backport e2e upgrade test for KEDA operator

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -70,3 +70,54 @@ jobs:
 
       - name: Test build
         run: make docker-build
+
+  e2e:
+    name: E2E Smoke Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.25'
+
+      - name: Create kind cluster with local registry
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        env:
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION: "v0.32.0"
+          # renovate: datasource=docker depName=kindest/node
+          KIND_NODE_VERSION: "v1.36.1"
+        with:
+          cluster_name: kind
+          node_image: kindest/node:${{ env.KIND_NODE_VERSION }}
+          registry: true
+          version: ${{ env.KIND_VERSION }}
+
+      - name: Install OLM
+        env:
+          # renovate: datasource=github-releases depName=operator-framework/operator-lifecycle-manager
+          OLM_VERSION: "v0.45.0"
+        run: make operator-sdk && ./bin/operator-sdk olm install --version "$OLM_VERSION"
+
+      - name: Build and deploy operator via OLM
+        run: make e2e-olm-setup
+        env:
+          IMAGE_REGISTRY: kind-registry:5000
+
+      - name: Run e2e tests
+        run: make e2e-test-ci
+
+      - name: Diagnostics
+        if: failure()
+        run: |
+          echo "=== All pods ==="
+          kubectl get pods -A
+          echo "=== Pods in keda namespace ==="
+          kubectl describe pods -n keda
+          echo "=== OLM resources ==="
+          kubectl get csv,sub,installplan -n keda 2>/dev/null || true
+          echo "=== Operator logs ==="
+          kubectl logs -n keda -l app.kubernetes.io/part-of=keda-olm-operator --tail=200 || true

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -121,3 +121,75 @@ jobs:
           kubectl get csv,sub,installplan -n keda 2>/dev/null || true
           echo "=== Operator logs ==="
           kubectl logs -n keda -l app.kubernetes.io/part-of=keda-olm-operator --tail=200 || true
+
+  e2e-upgrade:
+    name: E2E Upgrade Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26'
+
+      - name: Create kind cluster with local registry
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        env:
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kind
+          KIND_VERSION: "v0.32.0"
+          # renovate: datasource=docker depName=kindest/node
+          KIND_NODE_VERSION: "v1.36.1"
+        with:
+          cluster_name: kind
+          node_image: kindest/node:${{ env.KIND_NODE_VERSION }}
+          registry: true
+          version: ${{ env.KIND_VERSION }}
+
+      - name: Install OLM
+        env:
+          # renovate: datasource=github-releases depName=operator-framework/operator-lifecycle-manager
+          OLM_VERSION: "v0.45.0"
+        run: make operator-sdk && ./bin/operator-sdk olm install --version "$OLM_VERSION"
+
+      - name: Build operator and bundle images
+        run: make e2e-olm-upgrade-build
+        env:
+          IMAGE_REGISTRY: kind-registry:5000
+
+      - name: Install previous operator version
+        run: make e2e-olm-upgrade-install
+        env:
+          IMAGE_REGISTRY: kind-registry:5000
+
+      - name: Deploy workloads under previous version
+        run: make e2e-upgrade-test-pre-ci
+
+      - name: Upgrade operator to current build
+        run: make e2e-olm-upgrade-apply
+        env:
+          IMAGE_REGISTRY: kind-registry:5000
+
+      - name: Verify workloads survive upgrade
+        run: make e2e-upgrade-test-post-ci
+
+      - name: Diagnostics
+        if: failure()
+        run: |
+          echo "=== All pods ==="
+          kubectl get pods -A
+          echo "=== Pods in keda namespace ==="
+          kubectl describe pods -n keda
+          echo "=== OLM resources ==="
+          kubectl get csv,sub,installplan -n keda 2>/dev/null || true
+          echo "=== Operator logs ==="
+          kubectl logs -n keda -l app.kubernetes.io/part-of=keda-olm-operator --tail=200 || true
+          echo "=== KEDA operator logs ==="
+          kubectl logs -n keda deployment/keda-operator --tail=200 || true
+          echo "=== Workload namespace ==="
+          kubectl get all -n keda-upgrade-test 2>/dev/null || true
+          echo "=== ScaledObjects ==="
+          kubectl get scaledobjects -n keda-upgrade-test -o yaml 2>/dev/null || true
+          echo "=== HPAs ==="
+          kubectl get hpa -n keda-upgrade-test -o yaml 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,25 @@ test-deployment: manifests generate fmt vet envtest ## Test OLM deployment.
 test: manifests generate fmt vet envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -v -ginkgo.v -coverprofile cover.out -test.type unit
 
+.PHONY: e2e-test
+e2e-test: ## Run e2e smoke tests against existing cluster.
+	go test -tags=e2e -count=1 -timeout=10m -v ./test/e2e/...
+
+.PHONY: e2e-test-ci
+e2e-test-ci: ## Run e2e smoke tests (CI mode with GitHub Actions output).
+	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --rerun-fails=2 --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m
+
+.PHONY: e2e-olm-setup
+e2e-olm-setup: build bundle docker-build docker-push bundle-build bundle-push ## Deploy operator via OLM for e2e testing.
+	kubectl create namespace keda --dry-run=client -o yaml | kubectl apply --server-side -f -
+	kubectl annotate namespace keda keda-olm-operator/create-default-controller=skip --overwrite
+	$(OPERATOR_SDK) run bundle $(BUNDLE) --namespace keda --use-http --timeout 5m $(BUNDLE_RUN_OPTS)
+	kubectl rollout status deployment/keda-olm-operator -n keda --timeout=120s
+
+.PHONY: e2e-olm-cleanup
+e2e-olm-cleanup: operator-sdk ## Clean up OLM-deployed operator.
+	- $(OPERATOR_SDK) cleanup keda --namespace keda
+
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
@@ -172,9 +191,14 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
+# renovate: datasource=github-releases depName=operator-framework/operator-sdk
+OPERATOR_SDK_VERSION ?= v1.38.0
+# renovate: datasource=go depName=gotest.tools/gotestsum
+GOTESTSUM_VERSION ?= v1.13.0
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Install controller-gen from vendor dir if necessary.
@@ -194,6 +218,17 @@ $(KUSTOMIZE): $(LOCALBIN)
 envtest: $(ENVTEST) ## Install envtest-setup from vendor dir if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest
+
+.PHONY: operator-sdk
+operator-sdk: $(OPERATOR_SDK) ## Download operator-sdk locally if necessary.
+$(OPERATOR_SDK): $(LOCALBIN)
+	@if test -x $(LOCALBIN)/operator-sdk && ! $(LOCALBIN)/operator-sdk version | grep -q $(OPERATOR_SDK_VERSION); then \
+	    echo "$(LOCALBIN)/operator-sdk version is not expected $(OPERATOR_SDK_VERSION). Removing it before downloading."; \
+	    rm -rf $(LOCALBIN)/operator-sdk; \
+	fi
+	test -s $(LOCALBIN)/operator-sdk || \
+	    { curl -sSLo $(LOCALBIN)/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$$(go env GOOS)_$$(go env GOARCH) && \
+	    chmod +x $(LOCALBIN)/operator-sdk; }
 
 # Run golangci against code
 .PHONY: golangci

--- a/Makefile
+++ b/Makefile
@@ -92,17 +92,74 @@ test: manifests generate fmt vet envtest
 
 .PHONY: e2e-test
 e2e-test: ## Run e2e smoke tests against existing cluster.
-	go test -tags=e2e -count=1 -timeout=10m -v ./test/e2e/...
+	go test -tags=e2e -count=1 -timeout=10m -v -run=TestKedaControllerLifecycle ./test/e2e/...
 
 .PHONY: e2e-test-ci
 e2e-test-ci: ## Run e2e smoke tests (CI mode with GitHub Actions output).
-	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --rerun-fails=2 --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m
+	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --rerun-fails=2 --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m -run=TestKedaControllerLifecycle
+
+.PHONY: e2e-upgrade-test-pre
+e2e-upgrade-test-pre: ## Run pre-upgrade e2e test: deploy workloads under the previous KEDA version.
+	go test -tags=e2e -count=1 -timeout=10m -v -run=TestKedaUpgradeSetup ./test/e2e/...
+
+.PHONY: e2e-upgrade-test-pre-ci
+e2e-upgrade-test-pre-ci: ## Run pre-upgrade e2e test (CI mode).
+	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m -run=TestKedaUpgradeSetup
+
+.PHONY: e2e-upgrade-test-post
+e2e-upgrade-test-post: ## Run post-upgrade e2e test: verify workloads survived the upgrade.
+	go test -tags=e2e -count=1 -timeout=10m -v -run=TestKedaUpgradeVerify ./test/e2e/...
+
+.PHONY: e2e-upgrade-test-post-ci
+e2e-upgrade-test-post-ci: ## Run post-upgrade e2e test (CI mode).
+	go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) --format=github-actions --packages="./test/e2e/..." -- -tags=e2e -count=1 -timeout=10m -run=TestKedaUpgradeVerify
 
 .PHONY: e2e-olm-setup
 e2e-olm-setup: build bundle docker-build docker-push bundle-build bundle-push ## Deploy operator via OLM for e2e testing.
 	kubectl create namespace keda --dry-run=client -o yaml | kubectl apply --server-side -f -
 	kubectl annotate namespace keda keda-olm-operator/create-default-controller=skip --overwrite
 	$(OPERATOR_SDK) run bundle $(BUNDLE) --namespace keda --use-http --timeout 5m $(BUNDLE_RUN_OPTS)
+	kubectl rollout status deployment/keda-olm-operator -n keda --timeout=120s
+
+# Previous KEDA version used as the upgrade starting point, auto-detected from
+# the latest GitHub release. Uses deferred simple variable expansion so the shell
+# command runs at most once and only when actually referenced.
+E2E_PREVIOUS_KEDA_VERSION ?= $(eval E2E_PREVIOUS_KEDA_VERSION := $$(shell curl -s https://api.github.com/repos/kedacore/keda-olm-operator/releases/latest | jq -r '.name[1:]'))$(E2E_PREVIOUS_KEDA_VERSION)
+# Synthetic semver for the upgrade bundle CSV so OLM sees a distinct, newer entry.
+E2E_UPGRADE_CSV_FAKE_VERSION ?= 1000.0.0
+E2E_PREVIOUS_BUNDLE = $(IMAGE_REGISTRY)/$(IMAGE_REPO)/keda-olm-operator-bundle:$(E2E_PREVIOUS_KEDA_VERSION)
+
+.PHONY: e2e-olm-upgrade-build
+e2e-olm-upgrade-build: operator-sdk ## Build operator and both bundle images for upgrade testing.
+	$(MAKE) build docker-build docker-push
+	printf 'FROM scratch\nCOPY manifests/ /manifests/\nCOPY metadata/ /metadata/\n' | \
+		docker build -f - -t $(E2E_PREVIOUS_BUNDLE) \
+		--label operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \
+		--label operators.operatorframework.io.bundle.manifests.v1=manifests/ \
+		--label operators.operatorframework.io.bundle.metadata.v1=metadata/ \
+		--label operators.operatorframework.io.bundle.package.v1=keda \
+		--label operators.operatorframework.io.bundle.channels.v1=stable \
+		--label operators.operatorframework.io.bundle.channel.default.v1=stable \
+		keda/$(E2E_PREVIOUS_KEDA_VERSION)
+	docker push $(E2E_PREVIOUS_BUNDLE)
+	$(MAKE) bundle
+	cd bundle/manifests && \
+		sed -i 's/^  name: keda\.v.*/  name: keda.v$(E2E_UPGRADE_CSV_FAKE_VERSION)/' keda.clusterserviceversion.yaml && \
+		sed -i 's/^  version: .*/  version: $(E2E_UPGRADE_CSV_FAKE_VERSION)/' keda.clusterserviceversion.yaml && \
+		sed -i 's/replaces: keda\.v.*/replaces: keda.v$(E2E_PREVIOUS_KEDA_VERSION)/' keda.clusterserviceversion.yaml && \
+		sed -i '/matchLabels:/,/name:/{/app.kubernetes.io\/version:/d}' keda.clusterserviceversion.yaml
+	$(MAKE) bundle-build bundle-push
+
+.PHONY: e2e-olm-upgrade-install
+e2e-olm-upgrade-install: operator-sdk ## Install the previous operator version via OLM.
+	kubectl create namespace keda --dry-run=client -o yaml | kubectl apply --server-side -f -
+	kubectl annotate namespace keda keda-olm-operator/create-default-controller=skip --overwrite
+	$(OPERATOR_SDK) run bundle $(E2E_PREVIOUS_BUNDLE) --namespace keda --use-http --timeout 5m $(BUNDLE_RUN_OPTS)
+	kubectl rollout status deployment/keda-olm-operator -n keda --timeout=120s
+
+.PHONY: e2e-olm-upgrade-apply
+e2e-olm-upgrade-apply: operator-sdk ## Upgrade the operator to the current bundle.
+	$(OPERATOR_SDK) run bundle-upgrade $(BUNDLE) --namespace keda --use-http --timeout 5m $(BUNDLE_RUN_OPTS)
 	kubectl rollout status deployment/keda-olm-operator -n keda --timeout=120s
 
 .PHONY: e2e-olm-cleanup

--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../default
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: keda-olm-operator
+      spec:
+        template:
+          spec:
+            containers:
+              - name: keda-olm-operator
+                imagePullPolicy: Never
+  # Skip auto-creation of default KedaController CR, e2e tests create it explicitly.
+  - patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: keda
+        annotations:
+          keda-olm-operator/create-default-controller: "skip"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,243 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
+)
+
+const (
+	namespace = "keda"
+
+	pollInterval = 2 * time.Second
+	pollTimeout  = 3 * time.Minute
+)
+
+var (
+	coreDeployments = []string{
+		"keda-operator",
+		"keda-metrics-apiserver",
+		"keda-admission",
+	}
+
+	httpAddonDeployments = []string{
+		"keda-add-ons-http-operator",
+		"keda-add-ons-http-interceptor",
+		"keda-add-ons-http-scaler",
+	}
+)
+
+func TestKedaControllerLifecycle(t *testing.T) {
+	ctx := t.Context()
+	c := newClient(t)
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+
+		kc := &kedav1alpha1.KedaController{}
+		if err := c.Get(cleanupCtx, client.ObjectKey{Name: "keda", Namespace: namespace}, kc); err != nil {
+			return
+		}
+		if err := c.Delete(cleanupCtx, kc); err != nil {
+			t.Logf("cleanup: failed to delete KedaController: %v", err)
+			return
+		}
+
+		waitForDeploymentGone(t, cleanupCtx, c, coreDeployments[0])
+	})
+
+	step(t, "create KedaController", func(t *testing.T) {
+		kc := &kedav1alpha1.KedaController{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "keda",
+				Namespace: namespace,
+			},
+		}
+		if err := c.Create(ctx, kc); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				t.Fatalf("creating KedaController: %v", err)
+			}
+		}
+	})
+
+	step(t, "core KEDA deployments become ready", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			waitForDeploymentReady(t, ctx, c, name)
+		}
+	})
+
+	step(t, "KedaController status shows success", func(t *testing.T) {
+		var kc kedav1alpha1.KedaController
+		err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+			if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, &kc); err != nil {
+				if apierrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("unexpected error checking KedaController status: %w", err)
+			}
+			return kc.Status.Phase == kedav1alpha1.PhaseInstallSucceeded, nil
+		})
+		if err != nil {
+			t.Fatalf("KedaController status did not reach %q: %v", kedav1alpha1.PhaseInstallSucceeded, err)
+		}
+
+		for _, name := range coreDeployments {
+			logDeploymentImage(t, ctx, c, name)
+		}
+	})
+
+	step(t, "enabling HTTP add-on deploys add-on components", func(t *testing.T) {
+		kc := &kedav1alpha1.KedaController{}
+		if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, kc); err != nil {
+			t.Fatalf("getting KedaController: %v", err)
+		}
+		kc.Spec.HTTPAddon.Enabled = true
+		if err := c.Update(ctx, kc); err != nil {
+			t.Fatalf("enabling HTTP add-on: %v", err)
+		}
+
+		for _, name := range httpAddonDeployments {
+			waitForDeploymentReady(t, ctx, c, name)
+		}
+
+		var updated kedav1alpha1.KedaController
+		err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+			if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, &updated); err != nil {
+				return false, fmt.Errorf("getting KedaController for HTTP add-on status: %w", err)
+			}
+			return updated.Status.HTTPAddon != nil && updated.Status.HTTPAddon.Phase == kedav1alpha1.PhaseInstallSucceeded, nil
+		})
+		if err != nil {
+			t.Fatalf("HTTP add-on status did not reach %q: %v", kedav1alpha1.PhaseInstallSucceeded, err)
+		}
+
+		for _, name := range httpAddonDeployments {
+			logDeploymentImage(t, ctx, c, name)
+		}
+	})
+
+	step(t, "disabling HTTP add-on removes add-on components", func(t *testing.T) {
+		kc := &kedav1alpha1.KedaController{}
+		if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, kc); err != nil {
+			t.Fatalf("getting KedaController: %v", err)
+		}
+		kc.Spec.HTTPAddon.Enabled = false
+		if err := c.Update(ctx, kc); err != nil {
+			t.Fatalf("disabling HTTP add-on: %v", err)
+		}
+
+		for _, name := range httpAddonDeployments {
+			waitForDeploymentGone(t, ctx, c, name)
+		}
+	})
+
+	step(t, "deleting KedaController cleans up resources", func(t *testing.T) {
+		kc := &kedav1alpha1.KedaController{}
+		if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, kc); err != nil {
+			t.Fatalf("getting KedaController for deletion: %v", err)
+		}
+		if err := c.Delete(ctx, kc); err != nil {
+			t.Fatalf("deleting KedaController: %v", err)
+		}
+
+		for _, name := range coreDeployments {
+			waitForDeploymentGone(t, ctx, c, name)
+		}
+	})
+}
+
+func step(t *testing.T, name string, fn func(t *testing.T)) {
+	t.Helper()
+	if !t.Run(name, fn) {
+		t.FailNow()
+	}
+}
+
+func newClient(t *testing.T) client.Client {
+	t.Helper()
+
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, nil).ClientConfig()
+	if err != nil {
+		t.Fatalf("loading kubeconfig: %v", err)
+	}
+
+	if err := kedav1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("registering KedaController scheme: %v", err)
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		t.Fatalf("creating client: %v", err)
+	}
+	return c
+}
+
+func waitForDeploymentReady(t *testing.T, ctx context.Context, c client.Client, name string) {
+	t.Helper()
+	t.Logf("waiting for deployment %s/%s to become ready", namespace, name)
+
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+		dep := &appsv1.Deployment{}
+		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("unexpected error checking deployment %s: %w", name, err)
+		}
+		for _, cond := range dep.Status.Conditions {
+			if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("deployment %s/%s did not become ready: %v", namespace, name, err)
+	}
+}
+
+func waitForDeploymentGone(t *testing.T, ctx context.Context, c client.Client, name string) {
+	t.Helper()
+	t.Logf("waiting for deployment %s/%s to be deleted", namespace, name)
+
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+		dep := &appsv1.Deployment{}
+		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, dep); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("unexpected error checking deployment %s: %w", name, err)
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("deployment %s/%s was not deleted: %v", namespace, name, err)
+	}
+}
+
+func logDeploymentImage(t *testing.T, ctx context.Context, c client.Client, name string) {
+	t.Helper()
+
+	dep := &appsv1.Deployment{}
+	if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, dep); err != nil {
+		t.Fatalf("could not get deployment %s for image info: %v", name, err)
+	}
+	for _, container := range dep.Spec.Template.Spec.Containers {
+		t.Logf("%s: %s", name, container.Image)
+	}
+}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,0 +1,360 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kedav1alpha1 "github.com/kedacore/keda-olm-operator/api/keda/v1alpha1"
+)
+
+const (
+	workloadNamespace = "keda-upgrade-test"
+
+	scaledDeploymentName = "test-consumer"
+	scaledObjectName     = "test-scaledobject"
+
+	upgradePollInterval = 2 * time.Second
+	upgradePollTimeout  = 5 * time.Minute
+	scalingPollTimeout  = 3 * time.Minute
+)
+
+var (
+	scaledObjectGVK = schema.GroupVersionKind{
+		Group:   "keda.sh",
+		Version: "v1alpha1",
+		Kind:    "ScaledObject",
+	}
+)
+
+// TestKedaUpgradeSetup runs under the previous KEDA operator version (installed
+// by e2e-olm-upgrade-install). It creates a KedaController, deploys a workload
+// with a ScaledObject, and verifies the scaling pipeline works. All resources
+// are left in place so TestKedaUpgradeVerify can check them after the upgrade.
+func TestKedaUpgradeSetup(t *testing.T) {
+	ctx := t.Context()
+	c := newClient(t)
+
+	step(t, "install KEDA via KedaController", func(t *testing.T) {
+		kc := &kedav1alpha1.KedaController{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "keda",
+				Namespace: namespace,
+			},
+		}
+		if err := c.Create(ctx, kc); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("creating KedaController: %v", err)
+		}
+	})
+
+	step(t, "core KEDA deployments become ready", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			waitForDeploymentReady(t, ctx, c, name)
+		}
+	})
+
+	step(t, "KedaController status shows success", func(t *testing.T) {
+		version := waitForKedaControllerSuccess(t, ctx, c)
+		t.Logf("pre-upgrade KEDA version: %s", version)
+	})
+
+	step(t, "log pre-upgrade deployment images", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			logDeploymentImage(t, ctx, c, name)
+		}
+	})
+
+	step(t, "create workload namespace", func(t *testing.T) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: workloadNamespace},
+		}
+		if err := c.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			t.Fatalf("creating workload namespace: %v", err)
+		}
+	})
+
+	step(t, "deploy scaling workload", func(t *testing.T) {
+		createScalingWorkload(t, ctx, c)
+	})
+
+	step(t, "ScaledObject becomes ready under previous version", func(t *testing.T) {
+		waitForScaledObjectReady(t, ctx, c)
+	})
+
+	step(t, "HPA created under previous version", func(t *testing.T) {
+		verifyHPACreated(t, ctx, c)
+	})
+}
+
+// TestKedaUpgradeVerify runs after the operator has been upgraded to the
+// current build (by e2e-olm-upgrade-apply). It verifies that the ScaledObject
+// and HPA created by TestKedaUpgradeSetup are still functional, then cleans up.
+func TestKedaUpgradeVerify(t *testing.T) {
+	ctx := t.Context()
+	c := newClient(t)
+
+	t.Cleanup(func() {
+		cleanupCtx := context.Background()
+		cleanupUpgradeResources(t, cleanupCtx, c)
+	})
+
+	step(t, "core KEDA deployments ready after upgrade", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			waitForDeploymentReady(t, ctx, c, name)
+		}
+	})
+
+	step(t, "KedaController status shows success after upgrade", func(t *testing.T) {
+		version := waitForKedaControllerSuccess(t, ctx, c)
+		t.Logf("post-upgrade KEDA version: %s", version)
+	})
+
+	step(t, "log post-upgrade deployment images", func(t *testing.T) {
+		for _, name := range coreDeployments {
+			logDeploymentImage(t, ctx, c, name)
+		}
+	})
+
+	step(t, "pre-existing ScaledObject still ready after upgrade", func(t *testing.T) {
+		waitForScaledObjectReady(t, ctx, c)
+	})
+
+	step(t, "pre-existing HPA still present after upgrade", func(t *testing.T) {
+		verifyHPACreated(t, ctx, c)
+	})
+
+	step(t, "cleanup upgrade test resources", func(t *testing.T) {
+		cleanupUpgradeResources(t, ctx, c)
+	})
+}
+
+func waitForKedaControllerSuccess(t *testing.T, ctx context.Context, c client.Client) string {
+	t.Helper()
+	var kc kedav1alpha1.KedaController
+	err := wait.PollUntilContextTimeout(ctx, upgradePollInterval, upgradePollTimeout, true, func(ctx context.Context) (bool, error) {
+		if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, &kc); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("checking KedaController status: %w", err)
+		}
+		return kc.Status.Phase == kedav1alpha1.PhaseInstallSucceeded, nil
+	})
+	if err != nil {
+		t.Fatalf("KedaController did not reach %q: %v", kedav1alpha1.PhaseInstallSucceeded, err)
+	}
+	return kc.Status.Version
+}
+
+func createScalingWorkload(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+
+	replicas := int32(1)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scaledDeploymentName,
+			Namespace: workloadNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": scaledDeploymentName},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": scaledDeploymentName},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "consumer",
+							Image:   "registry.k8s.io/pause:3.9",
+							Command: []string{"/pause"},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("16Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := c.Create(ctx, dep); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating workload deployment: %v", err)
+	}
+
+	t.Log("waiting for workload deployment to become ready")
+	err := wait.PollUntilContextTimeout(ctx, upgradePollInterval, upgradePollTimeout, true, func(ctx context.Context) (bool, error) {
+		d := &appsv1.Deployment{}
+		if err := c.Get(ctx, client.ObjectKey{Name: scaledDeploymentName, Namespace: workloadNamespace}, d); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		for _, cond := range d.Status.Conditions {
+			if cond.Type == appsv1.DeploymentAvailable && cond.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("workload deployment did not become ready: %v", err)
+	}
+
+	so := newScaledObject()
+	if err := c.Create(ctx, so); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("creating ScaledObject: %v", err)
+	}
+}
+
+func newScaledObject() *unstructured.Unstructured {
+	so := &unstructured.Unstructured{}
+	so.SetGroupVersionKind(scaledObjectGVK)
+	so.SetName(scaledObjectName)
+	so.SetNamespace(workloadNamespace)
+
+	so.Object["spec"] = map[string]any{
+		"scaleTargetRef": map[string]any{
+			"name": scaledDeploymentName,
+		},
+		"minReplicaCount": int64(1),
+		"maxReplicaCount": int64(5),
+		"cooldownPeriod":  int64(10),
+		"triggers": []any{
+			map[string]any{
+				"type":       "cpu",
+				"metricType": string(autoscalingv2.UtilizationMetricType),
+				"metadata": map[string]any{
+					"value": "50",
+				},
+			},
+		},
+	}
+	return so
+}
+
+func waitForScaledObjectReady(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+	t.Log("waiting for ScaledObject to become ready")
+
+	err := wait.PollUntilContextTimeout(ctx, upgradePollInterval, scalingPollTimeout, true, func(ctx context.Context) (bool, error) {
+		so := &unstructured.Unstructured{}
+		so.SetGroupVersionKind(scaledObjectGVK)
+		if err := c.Get(ctx, client.ObjectKey{Name: scaledObjectName, Namespace: workloadNamespace}, so); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("getting ScaledObject: %w", err)
+		}
+
+		conditions, found, err := unstructured.NestedSlice(so.Object, "status", "conditions")
+		if err != nil || !found {
+			return false, nil
+		}
+
+		for _, c := range conditions {
+			cond, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			condType, _, _ := unstructured.NestedString(cond, "type")
+			condStatus, _, _ := unstructured.NestedString(cond, "status")
+			if condType == "Ready" && condStatus == "True" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("ScaledObject %s/%s did not become ready: %v", workloadNamespace, scaledObjectName, err)
+	}
+}
+
+func verifyHPACreated(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+
+	hpaName := "keda-hpa-" + scaledObjectName
+	t.Logf("checking HPA %s/%s exists", workloadNamespace, hpaName)
+
+	err := wait.PollUntilContextTimeout(ctx, upgradePollInterval, scalingPollTimeout, true, func(ctx context.Context) (bool, error) {
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{}
+		if err := c.Get(ctx, client.ObjectKey{Name: hpaName, Namespace: workloadNamespace}, hpa); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("getting HPA: %w", err)
+		}
+
+		t.Logf("HPA %s: currentReplicas=%d, desiredReplicas=%d, minReplicas=%d, maxReplicas=%d",
+			hpaName,
+			hpa.Status.CurrentReplicas,
+			hpa.Status.DesiredReplicas,
+			*hpa.Spec.MinReplicas,
+			hpa.Spec.MaxReplicas)
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("HPA %s/%s was not created by KEDA: %v", workloadNamespace, hpaName, err)
+	}
+}
+
+func cleanupUpgradeResources(t *testing.T, ctx context.Context, c client.Client) {
+	t.Helper()
+
+	so := &unstructured.Unstructured{}
+	so.SetGroupVersionKind(scaledObjectGVK)
+	so.SetName(scaledObjectName)
+	so.SetNamespace(workloadNamespace)
+	if err := c.Delete(ctx, so); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete ScaledObject: %v", err)
+	}
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scaledDeploymentName,
+			Namespace: workloadNamespace,
+		},
+	}
+	if err := c.Delete(ctx, dep); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete workload deployment: %v", err)
+	}
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: workloadNamespace}}
+	if err := c.Delete(ctx, ns); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete workload namespace: %v", err)
+	}
+
+	kc := &kedav1alpha1.KedaController{}
+	if err := c.Get(ctx, client.ObjectKey{Name: "keda", Namespace: namespace}, kc); err != nil {
+		return
+	}
+	if err := c.Delete(ctx, kc); err != nil && !apierrors.IsNotFound(err) {
+		t.Logf("cleanup: failed to delete KedaController: %v", err)
+		return
+	}
+	waitForDeploymentGone(t, ctx, c, coreDeployments[0])
+}


### PR DESCRIPTION
Backport (cherry-pick) of upstream `kedacore/keda-olm-operator` changes to this OpenShift downstream fork.

PR [#313](https://github.com/kedacore/keda-olm-operator/pull/313) (`Add e2e upgrade test for KEDA operator`) is not self-contained: it builds on the e2e framework introduced by [#303](https://github.com/kedacore/keda-olm-operator/pull/303) (`test: add e2e smoke tests with kind cluster in CI`), which this fork did not have. Both are backported, in order:

- `UPSTREAM: 303: test: add e2e smoke tests with kind cluster in CI`
- `UPSTREAM: 313: Add e2e upgrade test for KEDA operator`

What's included:
- `test/e2e/e2e_test.go` (shared helpers + lifecycle smoke test) and `test/e2e/upgrade_test.go` (upgrade test)
- Makefile e2e targets (`e2e-test`, `e2e-olm-setup`, `e2e-olm-upgrade-*`, `e2e-upgrade-test-*`, `e2e-olm-cleanup`)
- `config/e2e/kustomization.yaml`
- `E2E Smoke Test` and `E2E Upgrade Test` kind-based GitHub Actions jobs in `.github/workflows/pr-tests.yml`
- `gotestsum` tool dependency (re-vendored)

Backport adaptations for this fork:
- Added the `OPERATOR_SDK` variable, `OPERATOR_SDK_VERSION`, and the `operator-sdk` download target (upstream already had these; this fork lacked them, and the e2e targets depend on them).
- Added only the `gotestsum` tool directive; this fork installs its other build tools via `go install` rather than the `go tool` directive.
- `go mod tidy` bumped the `go` directive to `1.25.7` and `k8s.io/api|apimachinery|client-go|component-base` from `0.35.2` to `0.35.3`, matching upstream #303's resolution.

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)