### PR TITLE
AUTOSCALE-841: Add bundle-previous.Dockerfile.ci for e2e upgrade CI jobs

### DIFF
--- a/bundle-previous.Dockerfile.ci
+++ b/bundle-previous.Dockerfile.ci
@@ -1,0 +1,44 @@
+# This builds the bundle for the SECOND most recent release under keda/. It is
+# used by the cma-e2e-upgrade-* CI jobs as the upgrade starting point: it shares
+# the same OLM package with the bundle built by bundle.Dockerfile.ci, and its
+# CSV is the one the most recent release's CSV replaces, so that
+# 'operator-sdk run bundle-upgrade' has a valid upgrade edge.
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 as builder
+
+# we need to build some things so we need the sources
+COPY . . 
+
+
+# bundle off our second most recent release 
+RUN VERSION=$(ls keda/ | sort -V  | tail -2 | head -1) && \ 
+  mv keda/$VERSION/manifests /manifests && \ 
+  mv keda/$VERSION/metadata  /metadata 
+       
+# if there are two csvs, the bundle will not validate, so delete the upstream one now that we're done using it
+RUN rm /manifests/keda.*.clusterserviceversion.yaml
+
+
+FROM scratch
+
+COPY --from=builder ./manifests/ /manifests/
+COPY --from=builder ./metadata/ /metadata/
+
+# OpenShift bundle labels 
+LABEL com.redhat.component="custom-metrics-autoscaler-operator-bundle-container" \
+      name="custom-metrics-autoscaler-operator-metadata-rhel-8" \
+      version="v0.0.0" \
+      summary="Custom Metrics Autoscaler for OpenShift bundle image" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="openshift,custom-metrics-autoscaler-operator" \
+      io.k8s.display-name="openshift-custom-metrics-autoscaler-operator" \
+      maintainer="AOS workloads team, <aos-workloads@redhat.com>" \
+      description="Custom Metrics Autoscaler for OpenShift bundle image" \
+      com.redhat.delivery.operator.bundle=true \
+      com.redhat.openshift.versions="v4.15" \
+      operators.operatorframework.io.bundle.channel.default.v1=stable \
+      operators.operatorframework.io.bundle.channels.v1=stable \
+      operators.operatorframework.io.bundle.manifests.v1=manifests/ \
+      operators.operatorframework.io.bundle.mediatype.v1="registry+v1" \
+      operators.operatorframework.io.bundle.metadata.v1=metadata/ \
+      operators.operatorframework.io.bundle.package.v1="openshift-custom-metrics-autoscaler-operator"


### PR DESCRIPTION
Builds the bundle for the second most recent release under keda/, used by the cma-e2e-upgrade-* CI jobs as the upgrade starting point.

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
