### PR TITLE
OCPBUGS-99746: CMA operator passes OpenSSL cipher names instead of IANA format to KEDA

### DIFF
--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -303,11 +303,14 @@ func (r *KedaControllerReconciler) tlsEnvVarTransforms(ctx context.Context, logg
 		logger.Error(err, "Failed to get TLS profile from APIServer; skipping TLS env var update")
 		return nil
 	}
-	minTLSVersion := strings.TrimPrefix(string(profile.MinTLSVersion), "Version")
-	cipherList := strings.Join(profile.Ciphers, ",")
+	minTLSVersion, ianaCiphers := util.ConvertTLSProfileSpec(profile)
+	if len(ianaCiphers) != len(profile.Ciphers) {
+		logger.Info("Some TLS profile ciphers could not be converted to IANA names and were dropped",
+			"requested", profile.Ciphers, "converted", ianaCiphers)
+	}
 	return []mf.Transformer{
 		transform.EnsureEnvVarInAllContainers(kedaTLSMinVersionEnvVar, minTLSVersion, r.Scheme),
-		transform.EnsureEnvVarInAllContainers(kedaTLSCipherListEnvVar, cipherList, r.Scheme),
+		transform.EnsureEnvVarInAllContainers(kedaTLSCipherListEnvVar, strings.Join(ianaCiphers, ","), r.Scheme),
 	}
 }
 

--- a/internal/controller/keda/util/tls.go
+++ b/internal/controller/keda/util/tls.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"strings"
+
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+)
+
+// ConvertTLSProfileSpec converts a TLSProfileSpec into env-var-ready values.
+// MinTLSVersion is converted from "VersionTLS12" to "TLS12".
+// Ciphers are converted from OpenSSL names to Go/IANA names; unknown ciphers are dropped.
+func ConvertTLSProfileSpec(profile openshiftconfigv1.TLSProfileSpec) (string, []string) {
+	minVer := strings.TrimPrefix(string(profile.MinTLSVersion), "Version")
+	ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites(profile.Ciphers)
+	return minVer, ianaCiphers
+}

--- a/internal/controller/keda/util/tls_test.go
+++ b/internal/controller/keda/util/tls_test.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"testing"
+
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
+)
+
+func TestConvertTLSProfileSpec(t *testing.T) {
+	tests := map[string]struct {
+		profile        openshiftconfigv1.TLSProfileSpec
+		wantMinVersion string
+		wantCiphers    []string
+	}{
+		"converts version and OpenSSL ciphers to IANA": {
+			profile: openshiftconfigv1.TLSProfileSpec{
+				MinTLSVersion: "VersionTLS12",
+				Ciphers:       []string{"ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-RSA-AES256-GCM-SHA384"},
+			},
+			wantMinVersion: "TLS12",
+			wantCiphers:    []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+		},
+		"passes through IANA cipher names unchanged": {
+			profile: openshiftconfigv1.TLSProfileSpec{
+				MinTLSVersion: "VersionTLS13",
+				Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+			},
+			wantMinVersion: "TLS13",
+			wantCiphers:    []string{"TLS_AES_128_GCM_SHA256"},
+		},
+		"handles nil cipher list": {
+			profile: openshiftconfigv1.TLSProfileSpec{
+				MinTLSVersion: "VersionTLS12",
+			},
+			wantMinVersion: "TLS12",
+			wantCiphers:    nil,
+		},
+		"drops unknown ciphers": {
+			profile: openshiftconfigv1.TLSProfileSpec{
+				MinTLSVersion: "VersionTLS12",
+				Ciphers:       []string{"ECDHE-ECDSA-AES128-GCM-SHA256", "MADE-UP-CIPHER"},
+			},
+			wantMinVersion: "TLS12",
+			wantCiphers:    []string{"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotMinVersion, gotCiphers := ConvertTLSProfileSpec(tc.profile)
+			if gotMinVersion != tc.wantMinVersion {
+				t.Errorf("minTLSVersion = %q, want %q", gotMinVersion, tc.wantMinVersion)
+			}
+			if len(gotCiphers) != len(tc.wantCiphers) {
+				t.Fatalf("ciphers length = %d, want %d\ngot:  %v\nwant: %v", len(gotCiphers), len(tc.wantCiphers), gotCiphers, tc.wantCiphers)
+			}
+			for i := range gotCiphers {
+				if gotCiphers[i] != tc.wantCiphers[i] {
+					t.Errorf("cipher[%d] = %q, want %q", i, gotCiphers[i], tc.wantCiphers[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a cherry-pick of upstream https://github.com/kedacore/keda-olm-operator/pull/320.

The operator passed raw OpenSSL-format cipher names from the OpenShift TLS profile to KEDA via env vars. KEDA parses ciphers using Go's `tls.CipherSuites()` which expects IANA names, so none of the OpenSSL names matched — KEDA silently ignored all ciphers and fell back to Go defaults.

### Changes
- Extract ConvertTLSProfileSpec to util package for testability
- Use library-go's OpenSSLToIANACipherSuites for cipher name conversion
- Add unit tests for conversion logic

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)