### PR TITLE
AUTOSCALE-966: Bump OCP builder image to Go 1.26

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,7 @@
 #@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_8_golang_1.20)
 #FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.20.5-202307171904.el8.g844e652 AS builder
 # 1. HACK: package channels don't refresh on the cee image if we're running in CI, so use the CI builder instead of the cee one
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as builder
 
 # 2. HACK: openshift CI doesn't support ENV in image builds, but it does support ARG, so make these ARGs
 ARG CI_UPSTREAM_VERSION_SANITIZED=main

--- a/bundle-previous.Dockerfile.ci
+++ b/bundle-previous.Dockerfile.ci
@@ -4,7 +4,7 @@
 # CSV is the one the most recent release's CSV replaces, so that
 # 'operator-sdk run bundle-upgrade' has a valid upgrade edge.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as builder
 
 # we need to build some things so we need the sources
 COPY . . 

--- a/bundle.Dockerfile.ci
+++ b/bundle.Dockerfile.ci
@@ -1,7 +1,7 @@
 # This enables us to build a release-ish image in CI. It won't be exactly the same as what we release, 
 # but it should approximate it well enough for now that it gives us some signal. 
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 as builder
 
 # we need to build some things so we need the sources
 COPY . . 


### PR DESCRIPTION
Update the builder image in Dockerfile.ci, bundle.Dockerfile.ci, and bundle-previous.Dockerfile.ci from rhel-9-golang-1.25-openshift-4.22 to rhel-9-golang-1.26-openshift-5.0.