### PR TITLE
OCPBUGS-84045: UPSTREAM: 282: Fix: Use correct spec fields for AdmissionWebhooks volumes

### DIFF
--- a/internal/controller/keda/kedacontroller_controller.go
+++ b/internal/controller/keda/kedacontroller_controller.go
@@ -1452,11 +1452,11 @@ func (r *KedaControllerReconciler) installAdmissionWebhooks(ctx context.Context,
 	}
 
 	if instance.Spec.AdmissionWebhooks.Volumes != nil {
-		transforms = append(transforms, transform.ReplaceDeploymentVolumes(instance.Spec.Operator.Volumes, r.Scheme))
+		transforms = append(transforms, transform.ReplaceDeploymentVolumes(instance.Spec.AdmissionWebhooks.Volumes, r.Scheme))
 	}
 
 	if instance.Spec.AdmissionWebhooks.VolumeMounts != nil {
-		transforms = append(transforms, transform.ReplaceDeploymentVolumeMounts(instance.Spec.Operator.VolumeMounts, r.Scheme))
+		transforms = append(transforms, transform.ReplaceDeploymentVolumeMounts(instance.Spec.AdmissionWebhooks.VolumeMounts, r.Scheme))
 	}
 
 	// add arbitrary args defined by user


### PR DESCRIPTION
Fixes [OCPBUGS-84045](https://redhat.atlassian.net/browse/OCPBUGS-84045)

This PR cherry-picks the fix from upstream PR https://github.com/kedacore/keda-olm-operator/pull/282

The `installAdmissionWebhooks` function was incorrectly using `Operator.Volumes` and `Operator.VolumeMounts` instead of `AdmissionWebhooks.Volumes` and `AdmissionWebhooks.VolumeMounts`.

This caused user-configured volumes for admission webhooks to not be applied correctly, as the operator's volumes were used instead.